### PR TITLE
Update `hyperbee-range-watcher-autobase` to support better diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ for the index.
 ### `SubIndex`
 
 Represents the index's db and provides a similar API to a `Hyperbee` database.
-Can only be created via `createIndex()`. Currently supports:
+Can only be created via `createIndex()`. Currently supports the following
+`Hyperbee` methods:
 
 - `await sub.put(key, value)`
 - `await sub.del(key)`
@@ -96,12 +97,8 @@ Can only be created via `createIndex()`. Currently supports:
 This debounced event triggers after the `callback` finishes running indicating
 the index has been updated based on the `ranges`' changes.
 
-#### `drain` event
-
-Triggered after a index callback is triggered and the watcher updates. Like
-stream's `drain` event, this event signals that the index is catch up and ready
-for more updates.
-
 #### `await sub.drained()`
 
-Returns a promise that is resolved when the next drain event is emitted.
+Triggered after a index callback is finished processing changes. Like stream's
+`drain` event, this event signals that the index is caught up and ready for more
+updates.

--- a/README.md
+++ b/README.md
@@ -101,3 +101,7 @@ the index has been updated based on the `ranges`' changes.
 Triggered after a index callback is triggered and the watcher updates. Like
 stream's `drain` event, this event signals that the index is catch up and ready
 for more updates.
+
+#### `await sub.drained()`
+
+Returns a promise that is resolved when the next drain event is emitted.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,59 @@ await sub.update()
 const node = await sub.get(key)
 console.log(node.value) // 4
 ```
+
+## API
+
+### `const hyperbeeLikeBase = wrap(base)`
+
+`wrap` adds functions to the `Autobase` `base` object with a `Hyperbee`
+`.view` to support a similar API to `Hyperbee`, eg. `.put(key, value)` &
+`.get(key)`.
+
+### `async apply (batch, bee, base)`
+
+This `apply` function provides the functionality necessary to process the
+`autobase` op log style input blocks for the API `wrap` provides. This is a
+convenience function to be used as / or composed with the `autobase`'s `apply`.
+
+### `const sub = await createIndex(name, base, ranges, callback, opts)`
+
+Create a `SubIndex` with the given `name` which updates, as described by the
+`callback`, when the `ranges` change on the provided `base`'s hyperbee `.view`.
+
+For example, the following creates a '2x' index which watches keys between
+`0`–`10` and updates an entry to 2 times the original value.:
+
+```js
+const [sub] = createIndex('2x', base, { lt: '10', gte: '0' }, async (node, sub) =>
+  sub.put(node.key, 2 * node.value))
+```
+
+`ranges` are the key ranges accepted by [`hyperbee-diff-stream`'s
+`opts`](https://github.com/holepunchto/hyperbee-diff-stream?tab=readme-ov-file#const-diffstream--new-beediffstreamleftsnapshot-rightsnapshot-options).
+
+`callback` is provided with the `node` that changed and the current `SubIndex`
+for the index.
+
+### `SubIndex`
+
+Represents the index's db and provides a similar API to a `Hyperbee` database.
+Can only be created via `createIndex()`. Currently supports:
+
+- `await sub.put(key, value)`
+- `await sub.del(key)`
+- `const { seq, key, value } = await sub.get(key)`
+- `sub.createReadStream(range, opts)`
+- `const { seq, key, value } = await sub.peek([range], [options])`
+- `await sub.update()`
+
+#### `update` event
+
+This debounced event triggers after the `callback` finishes running indicating
+the index has been updated based on the `ranges`' changes.
+
+#### `drain` event
+
+Triggered after a index callback is triggered and the watcher updates. Like
+stream's `drain` event, this event signals that the index is catch up and ready
+for more updates.

--- a/index.mjs
+++ b/index.mjs
@@ -84,7 +84,7 @@ class SubIndex extends EventEmitter {
       }
     })
 
-    if (this.base.view.version !== oldestWatcher.latest.version) {
+    if (this.base.view.version > oldestWatcher.latest.version) {
       return Promise.any([
         oldestWatcher.update(),
         // drop out early for  immediate updates
@@ -151,6 +151,9 @@ export const createIndex =
       dbVersionBefore = base.view.checkout(1)
     } else if (!prevVersion) {
       await base.put(name, version, { keyEncoding: indexMetaSubEnc })
+    } else if (prevVersion.value > version) {
+      console.warn(`The current index version [${prevVersion.value}] is newer than the declared version [${version}]. Upgrade needed. No indexing will happen.`)
+      return [sub]
     }
 
     // TODO Consider implementing a version that walks through the history of the

--- a/index.mjs
+++ b/index.mjs
@@ -78,6 +78,10 @@ class SubIndex extends EventEmitter {
     return new Promise((resolve) => this.once('update', resolve))
   }
 
+  drained () {
+    return new Promise((resolve) => this.once('drain', resolve))
+  }
+
   put (key, value) {
     return this.base.put(key, value, { keyEncoding: this.enc })
   }

--- a/index.mjs
+++ b/index.mjs
@@ -112,7 +112,7 @@ export const createIndex =
     await base.ready()
 
     // Default to only watching since db version when index is created
-    let dbVersionBefore = base.view.version
+    let dbVersionBefore = base.view.snapshot()
 
     const prevVersion = await base.get(name, { keyEncoding: indexMetaSubEnc })
     debug && console.log('prevVersion', prevVersion, 'version', version)
@@ -126,7 +126,7 @@ export const createIndex =
       }
 
       await Promise.all(proms)
-      dbVersionBefore = 0
+      dbVersionBefore = base.view.checkout(1)
     } else if (!prevVersion) {
       await base.put(name, version, { keyEncoding: indexMetaSubEnc })
     }

--- a/index.mjs
+++ b/index.mjs
@@ -165,5 +165,12 @@ export const createIndex =
       return watcher
     })
 
+    const indexVersionWatcher = await base.view.getAndWatch(name, { keyEncoding: indexMetaSubEnc })
+    indexVersionWatcher.on('update', () => {
+      if (indexVersionWatcher.node.value > version) {
+        watchers.map((w) => w.close())
+      }
+    })
+
     return [sub, watchers]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#1.1.0",
+        "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
         "hyperbee": "^2.18.2",
         "sub-encoder": "^2.1.3"
       },
@@ -161,11 +161,12 @@
       }
     },
     "node_modules/@lejeunerenard/hyperbee-range-watcher-autobase": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#44b9ebc14520429d30c995a5665a346711074e31",
+      "version": "1.1.1",
+      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#637ec35965224f8e2a6b919cb71dbe256bb92912",
       "license": "MIT",
       "dependencies": {
-        "hyperbee": "^2.12.0"
+        "hyperbee": "^2.12.0",
+        "hyperbee-diff-stream": "^1.0.2"
       }
     },
     "node_modules/@ljharb/resumer": {
@@ -1715,6 +1716,16 @@
         "streamx": "^2.12.4"
       }
     },
+    "node_modules/hyperbee-diff-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hyperbee-diff-stream/-/hyperbee-diff-stream-1.0.2.tgz",
+      "integrity": "sha512-fTU6v1Jy132AyTIDRVRUfLnhEd0tKmcEsGzQQlurJqWtXj6Ywj475On1QpiX4eZqBMr5Le35qBurIAfBMpzl+g==",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "codecs": "^3.0.0",
+        "sorted-union-stream": "^3.2.3"
+      }
+    },
     "node_modules/hypercore": {
       "version": "10.33.0",
       "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.33.0.tgz",
@@ -3048,6 +3059,14 @@
         "sodium-javascript": "~0.8.0",
         "sodium-native": "^4.0.0",
         "xsalsa20": "^1.0.0"
+      }
+    },
+    "node_modules/sorted-union-stream": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-3.2.3.tgz",
+      "integrity": "sha512-8wbehFBja6u/eVlrn87J9ybABl+BUcpG/Om/uu9yYQcHOzhPi779wkRX61OpgAy1Y9/smkGtlOW/m7oyfAhv+g==",
+      "dependencies": {
+        "streamx": "^2.6.0"
       }
     },
     "node_modules/stop-iteration-iterator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,11 +162,11 @@
     },
     "node_modules/@lejeunerenard/hyperbee-range-watcher-autobase": {
       "version": "1.1.1",
-      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#637ec35965224f8e2a6b919cb71dbe256bb92912",
+      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#e4715d5edca9377cf4db807c5c0407412c6fb81c",
       "license": "MIT",
       "dependencies": {
         "hyperbee": "^2.12.0",
-        "hyperbee-diff-stream": "^1.0.2"
+        "hyperbee-diff-stream": "github:lejeunerenard/hyperbee-diff-stream#fix-optional-values"
       }
     },
     "node_modules/@ljharb/resumer": {
@@ -1717,9 +1717,9 @@
       }
     },
     "node_modules/hyperbee-diff-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyperbee-diff-stream/-/hyperbee-diff-stream-1.0.2.tgz",
-      "integrity": "sha512-fTU6v1Jy132AyTIDRVRUfLnhEd0tKmcEsGzQQlurJqWtXj6Ywj475On1QpiX4eZqBMr5Le35qBurIAfBMpzl+g==",
+      "version": "1.0.3",
+      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-diff-stream.git#ccf4425957ec55eda8a91c04524a6d6b51fc66df",
+      "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.1",
         "codecs": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,7 @@
     },
     "node_modules/@lejeunerenard/hyperbee-range-watcher-autobase": {
       "version": "1.1.1",
-      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#e4715d5edca9377cf4db807c5c0407412c6fb81c",
+      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#0a0f99843bb482fefcfe92b25d4abdf1333ad850",
       "license": "MIT",
       "dependencies": {
         "hyperbee": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   "keywords": [],
   "author": "Sean Zellmer <sean@lejeunerenard.com> (http://lejeunerenard.com/)",
   "license": "MIT",
+  "imports": {
+    "events": {
+      "bare": "bare-events",
+      "default": "events"
+    }
+  },
   "devDependencies": {
     "autobase": "^6.0.0-rc0",
     "corestore": "^6.16.2",
@@ -25,5 +31,8 @@
     "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
     "hyperbee": "^2.18.2",
     "sub-encoder": "^2.1.3"
+  },
+  "optionalDependencies": {
+    "bare-events": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tape": "^5.7.4"
   },
   "dependencies": {
-    "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#1.1.0",
+    "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
     "hyperbee": "^2.18.2",
     "sub-encoder": "^2.1.3"
   }

--- a/tests/index-types.mjs
+++ b/tests/index-types.mjs
@@ -136,8 +136,12 @@ test('test various index types', (t) => {
   t.test('slow indexes', async (t) => {
     const base = makeBase()
     const range = { gte: 'entry!', lt: bump(b4a.from('entry!')) }
+
+    // Increase work with each iteration to simulate "exponential work"
+    let runCount = 1
     const [sub] = await createIndex('seconds later', base, range, async (node, sub) => {
-      await setTimeout(50)
+      runCount++
+      await setTimeout(runCount * 50)
       await sub.put(node.key, node.value)
     })
 
@@ -146,7 +150,7 @@ test('test various index types', (t) => {
       await base.put(getKey(i), i)
     }
 
-    await new Promise((resolve) => sub.on('drain', resolve))
+    await sub.drained()
 
     const total = await sub.get(getKey(16))
     t.notEqual(total, null, 'index was written to')

--- a/tests/index-types.mjs
+++ b/tests/index-types.mjs
@@ -170,7 +170,7 @@ test('test various index types', (t) => {
       await base.put(getKey(i), i)
     }
 
-    await new Promise((resolve) => sub.on('drain', resolve))
+    await sub.drained()
 
     const total = await sub.get(getKey(many))
     t.notEqual(total, null, 'index was written to')


### PR DESCRIPTION
Keys will now not double fire when the autobase backed hyperbee is updated and blocks are reindexed.